### PR TITLE
Add a quick fix to restore the vertical scroll position for phase one

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -11,6 +11,8 @@ export default function Card(props) {
   const enterPhaseOne = (event) => {
     setEnteringPhaseOne(true);
     props.displayAboveSections(false);
+    // quick fix restoring vertical scroll position for phase one page
+    window.scrollTo(0, 0);
   };
 
   return (


### PR DESCRIPTION
# Description

Opening a new page by clicking on the first card 'chapter one' did not reset the window's scroll position.

I added a quick fix reseting the scroll position while opening chapter one which does work reasonably well for now but should be fixed properly in the future.

The real issue is that the page for chapter one is not setup as a real new page and therefore not integrated in the browser's routing mechanism. The management of the scroll position (and the back navigation) is better left to the browser by leveraging separate pages instead of switching between components.

Note that while testing the fix locally the back button always navigates to the production website which still includes the error.
https://github.com/JUSTADDMETA/justaddmeta-minting-dapp/blob/84ba55ad700e8cd2ffd772732bd7b73ab69e67a4/src/components/Intro.js#L17

Let me now if you need further assistance.

## Type of change

Please select the option that is relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All the required documentation is added.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

# Additional information

_[Provided extra information if necessary]_
